### PR TITLE
Workaround so camcrypt can be imported on Python3.

### DIFF
--- a/pgp/cipher/__init__.py
+++ b/pgp/cipher/__init__.py
@@ -23,9 +23,22 @@ __all__ = ['aidea', 'camellia', 'twofish']
 
 try:
     import camcrypt
-    camcrypt.CamCrypt()
+    try:
+        camcrypt.CamCrypt()
+    except OSError:
+        # On python3 the lib is not called camellia.so, but something
+        # like camellia.cpython-34m.so. Use globbing to find a
+        # candidate. This should be fixed upstream in the camcrypt
+        # module instead.
+        import glob
+        import os
+        sofile = glob.glob(os.path.join(camcrypt.__path__[0], 'camellia*.so'))[0]
+        camcrypt.CamCrypt(libraryPath=sofile)
+        camcrypt_kwargs = {'libraryPath': sofile}
+    else:
+        camcrypt_kwargs = {}
     HAS_CAMELLIA = True
-except (ImportError, OSError):
+except (ImportError, IndexError, OSError):
     HAS_CAMELLIA = False
 
 

--- a/pgp/cipher/camellia.py
+++ b/pgp/cipher/camellia.py
@@ -17,6 +17,7 @@
 import camcrypt
 from Crypto.Cipher import blockalgo
 
+from pgp.cipher import camcrypt_kwargs
 from pgp.cipher.base import _InternalObj
 
 
@@ -30,7 +31,7 @@ class _CamelliaObj(_InternalObj):
 
     @classmethod
     def _create_impl(cls, key):
-        impl = camcrypt.CamCrypt()
+        impl = camcrypt.CamCrypt(**camcrypt_kwargs)
         impl.keygen(len(key) * 8, bytes(key))
         return impl
 


### PR DESCRIPTION
This should probably be fixed upstream, but the library explicitly
allows the caller to supply the path, so we might as well do that.

Before:

    >>> import camcrypt
    >>> camcrypt.CamCrypt()
    OSError: .../camcrypt/camellia.so: No such file or directory

And:

    Ran 75 tests in 0.412s

After:

    Ran 131 tests in 0.503s