### PR TITLE
Fix so nose doesn't run test methods that it shouldn't.

### DIFF
--- a/pgp/cipher/tests/test_aidea.py
+++ b/pgp/cipher/tests/test_aidea.py
@@ -14,8 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from Crypto.SelfTest.Cipher.common import make_block_tests
-
 from pgp.cipher import aidea
 
 
@@ -110,12 +108,9 @@ test_data = [
     ]
 
 
-def get_testcases(config={}):
-    testcases = make_block_tests(aidea, "AIDEA", test_data)
-    return testcases
-
-
 def test_aidea():
-    for testcase in get_testcases():
+    from Crypto.SelfTest.Cipher.common import make_block_tests
+
+    for testcase in make_block_tests(aidea, "AIDEA", test_data):
         # Hack for Nose
         yield getattr(testcase, testcase._testMethodName)

--- a/pgp/cipher/tests/test_camellia.py
+++ b/pgp/cipher/tests/test_camellia.py
@@ -18,8 +18,6 @@
 import unittest
 import warnings
 
-from Crypto.SelfTest.Cipher.common import make_block_tests
-
 from pgp.cipher import camellia
 
 
@@ -320,18 +318,16 @@ test_data = [
 ]
 
 
-def get_tests(config={}):
-    return make_block_tests(camellia, "Camellia", test_data)
-
-
 def test_camellia():
+    from Crypto.SelfTest.Cipher.common import make_block_tests
+
     if camellia is None:
         warnings.warn(
             "Camellia not available on this system. Skipping its tests."
             )
         return
 
-    for testcase in get_tests():
+    for testcase in make_block_tests(camellia, "Camellia", test_data):
         # Hack for Nose
         yield getattr(testcase, testcase._testMethodName)
 

--- a/pgp/cipher/tests/test_twofish.py
+++ b/pgp/cipher/tests/test_twofish.py
@@ -18,8 +18,6 @@
 import unittest
 import warnings
 
-from Crypto.SelfTest.Cipher.common import make_block_tests
-
 from pgp.cipher import twofish
 
 
@@ -101,17 +99,16 @@ test_data = [
 ]
 
 
-def get_tests(config={}):
-    return make_block_tests(twofish, "Twofish", test_data)
-
-
 def test_twofish():
+    from Crypto.SelfTest.Cipher.common import make_block_tests
+
     if twofish is None:
         warnings.warn(
             "Twofish not available on this system. Skipping its tests."
             )
         return
-    for testcase in get_tests():
+
+    for testcase in make_block_tests(twofish, "Twofish", test_data):
         # Hack for Nose
         yield getattr(testcase, testcase._testMethodName)
 


### PR DESCRIPTION
Quoting the nose docs:
> As with py.test, nose tests need not be subclasses of
> unittest.TestCase.  Any function or class that matches the configured
> testMatch regular expression ((?:^|[\\b_\\.-])[Tt]est by default [...])
> and lives in a module that also matches that expression will be run as
> a test.

Before:

    ======================================================================
    ERROR: pgp.cipher.tests.test_twofish.make_block_tests
    ----------------------------------------------------------------------
    TypeError: make_block_tests() missing 3 required positional arguments:
      'module', 'module_name', and 'test_data'

After:

    all is well