### PR TITLE
Fix extraneous argument in BaseResource._maybe_create().

### DIFF
--- a/pgp/db/gpg.py
+++ b/pgp/db/gpg.py
@@ -189,7 +189,7 @@ class BaseResource(object):
     def _maybe_create(self, force):
         if not os.path.exists(self.filename):
             if force:
-                self.create_db(self.filename)
+                self.create_db()
             else:
                 raise RuntimeError(
                     'Database {0} does not exist.'.format(self.filename))


### PR DESCRIPTION
An extraneous argument was in `BaseResource._maybe_create()` calling `self.create_db()`.